### PR TITLE
Capaz de fusionarse

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+            - nombre: caché
+  usos: acciones/cache@v4.0.2
+  con:
+    # Una lista de archivos, directorios y patrones comodín para almacenar en caché y restaurar
+    camino:
+    # Una clave explícita para restaurar y guardar el caché
+    llave:
+    # Una lista ordenada de claves que se utilizarán para restaurar el caché obsoleto si no se produjo ningún acierto en el caché para la clave. Tenga en cuenta que `cache-hit` devuelve falso en este caso.
+    restaurar claves: # opcional
+    # El tamaño del fragmento utilizado para dividir archivos grandes durante la carga, en bytes
+    tamaño del fragmento de carga: # opcional
+    # Un valor booleano opcional, cuando está habilitado, permite a los corredores de Windows guardar o restaurar cachés que se pueden restaurar o guardar respectivamente en otras plataformas.
+    enableCrossOsArchive: # opcional, el valor predeterminado es falso
+    # Falla el flujo de trabajo si no se encuentra la entrada de caché
+    fail-on-cache-miss: # opcional, el valor predeterminado es falso
+    # Comprobar si existe una entrada de caché para las entradas dadas (clave, claves de restauración) sin descargar el caché
+    solo búsqueda: # opcional, el valor predeterminado es falso
+    # Ejecute el paso de publicación para guardar el caché incluso si falla otro paso anterior
+    guardar-siempre: # opcional, el valor predeterminado es falso
+          


### PR DESCRIPTION
            - nombre: caché
  usos: acciones/cache@v4.0.2
  con:
    # Una lista de archivos, directorios y patrones comodín para almacenar en caché y restaurar
    camino:
    # Una clave explícita para restaurar y guardar el caché
    llave:
    # Una lista ordenada de claves que se utilizarán para restaurar el caché obsoleto si no se produjo ningún acierto en el caché para la clave. Tenga en cuenta que `cache-hit` devuelve falso en este caso.
    restaurar claves: # opcional
    # El tamaño del fragmento utilizado para dividir archivos grandes durante la carga, en bytes
    tamaño del fragmento de carga: # opcional
    # Un valor booleano opcional, cuando está habilitado, permite a los corredores de Windows guardar o restaurar cachés que se pueden restaurar o guardar respectivamente en otras plataformas.
    enableCrossOsArchive: # opcional, el valor predeterminado es falso
    # Falla el flujo de trabajo si no se encuentra la entrada de caché
    fail-on-cache-miss: # opcional, el valor predeterminado es falso
    # Comprobar si existe una entrada de caché para las entradas dadas (clave, claves de restauración) sin descargar el caché
    solo búsqueda: # opcional, el valor predeterminado es falso
    # Ejecute el paso de publicación para guardar el caché incluso si falla otro paso anterior
    guardar-siempre: # opcional, el valor predeterminado es falso
          